### PR TITLE
Introduce schema lock and automated migration rollback

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 gem "bundler-audit"
 gem "minitest"
+gem "minitest-focus"
 gem "minitest-reporters"
 gem "pry"
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,8 @@ GEM
     language_server-protocol (3.17.0.3)
     method_source (1.1.0)
     minitest (5.25.1)
+    minitest-focus (1.4.0)
+      minitest (>= 4, < 6)
     minitest-reporters (1.7.1)
       ansi
       builder
@@ -74,6 +76,7 @@ PLATFORMS
 DEPENDENCIES
   bundler-audit
   minitest
+  minitest-focus
   minitest-reporters
   pgi!
   pry

--- a/lib/pgi/schema_migrator.rb
+++ b/lib/pgi/schema_migrator.rb
@@ -53,11 +53,10 @@ module PGI
         raise "FATAL: version must be an integer >= 0" unless version.nil? || (version.is_a?(Integer) && version >= 0)
 
         config.migration_files.sort.each { |file| require file }
+        to_version = version || latest_migration.to_i
         fetch_migrations!
 
         raise "FATAL: Migration version does not exist" unless version.nil? || migrations.key?(version)
-
-        to_version = version || latest_migration.to_i
 
         if current_version == to_version
           puts "No migrations detected..."
@@ -69,8 +68,10 @@ module PGI
           puts "Schema lock acquired"
           current = current_version
           if current == to_version
+            # :nocov:
             puts "No migrations detected... after schema lock acquired"
             return
+            # :nocov:
           end
           walk       = to_version - current
           direction  = walk.positive? ? 1 : -1

--- a/lib/pgi/schema_migrator.rb
+++ b/lib/pgi/schema_migrator.rb
@@ -4,10 +4,24 @@ module PGI
     @migrations = Hash.new { |h, k| h[k] = {} }.merge(
       # Default migration
       0 => {
-        1 => "CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER," \
-             "created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP);",
-        -1 => "DROP TABLE schema_migrations;"
-      }
+        1 => <<~SQL,
+          CREATE TABLE IF NOT EXISTS schema_migrations (
+            version INTEGER,
+            created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+            up TEXT,
+            down TEXT
+          );
+          CREATE TABLE IF NOT EXISTS schema_lock (
+            locked_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NULL,
+            onerow BOOLEAN PRIMARY KEY DEFAULT TRUE CONSTRAINT onerow_uni CHECK (onerow)
+          );
+          INSERT INTO schema_lock DEFAULT VALUES ON CONFLICT DO NOTHING;
+        SQL
+        -1 => <<~SQL,
+          DROP TABLE schema_migrations;
+          DROP TABLE schema_lock;
+        SQL
+      },
     )
 
     def initialize(version)
@@ -39,30 +53,40 @@ module PGI
         raise "FATAL: version must be an integer >= 0" unless version.nil? || (version.is_a?(Integer) && version >= 0)
 
         config.migration_files.sort.each { |file| require file }
+        fetch_migrations!
 
         raise "FATAL: Migration version does not exist" unless version.nil? || migrations.key?(version)
 
         to_version = version || latest_migration.to_i
-        current    = current_version
-        walk       = to_version - current
-        direction  = walk.positive? ? 1 : -1
-        steps      =
-          if direction == 1
-            migrations.keys[(current + 1)..].to_a
-          else
-            migrations.keys[0..current].to_a.reverse
-          end.take(walk.abs)
 
-        if current == to_version
+        if current_version == to_version
           puts "No migrations detected..."
           return
         end
 
-        config.pg_conn.transaction do
-          steps.each do |v|
-            delete_version(v) if direction == -1
-            config.pg_conn.exec(migrations[v][direction])
-            add_version(v) if direction == 1
+        puts "Attemping to acquire schema lock"
+        schema_lock! do
+          puts "Schema lock acquired"
+          current = current_version
+          if current == to_version
+            puts "No migrations detected... after schema lock acquired"
+            return
+          end
+          walk       = to_version - current
+          direction  = walk.positive? ? 1 : -1
+          steps      =
+            if direction == 1
+              migrations.keys[(current + 1)..].to_a
+            else
+              migrations.keys[0..current].to_a.reverse
+            end.take(walk.abs)
+
+          config.pg_conn.transaction do
+            steps.each do |v|
+              delete_version(v) if direction == -1
+              config.pg_conn.exec(migrations[v][direction])
+              add_version(v) if direction == 1
+            end
           end
         end
       end
@@ -99,16 +123,66 @@ module PGI
         SQL
       end
 
+      def schema_lock!
+        loop do
+          success = acquire_lock!
+          if success
+            yield
+            release_lock!
+            return
+          else
+            sleep 1
+          end
+        end
+      end
+
+      def acquire_lock!
+        config.pg_conn.exec_params(<<~SQL, []).to_a.length == 1
+          UPDATE schema_lock
+          SET locked_at = NOW()
+          WHERE COALESCE(locked_at, '1970-1-1'::TIMESTAMP WITHOUT TIME ZONE) < NOW() - interval '15 seconds'
+          RETURNING *
+        SQL
+      rescue PG::UndefinedTable => e
+        raise unless e.message =~ /relation "schema_lock" does not exist/
+
+        true
+      end
+
+      def release_lock!
+        config.pg_conn.exec_params(<<~SQL, []).to_a
+          UPDATE schema_lock
+          SET locked_at = NULL
+        SQL
+        nil
+      rescue PG::UndefinedTable => e
+        raise unless e.message =~ /relation "schema_lock" does not exist/
+
+        nil
+      end
+
       private
+
+      def fetch_migrations!
+        result = config.pg_conn.exec_params(<<~SQL, [migrations.keys.max]).to_a
+          SELECT * from schema_migrations WHERE version > $1
+        SQL
+
+        @migrations = migrations.merge(result.to_h do |x|
+          [x["version"].to_i, { 1 => x["up"], -1 => x["down"] }]
+        end)
+      rescue PG::UndefinedTable => e
+        raise unless e.message =~ /relation "schema_migrations" does not exist/
+      end
 
       def latest_migration
         migrations.keys.max || -1
       end
 
       def add_version(version)
-        config.pg_conn.exec_params(<<~SQL, [version])
+        config.pg_conn.exec_params(<<~SQL, [version, migrations[version][1], migrations[version][-1]])
           INSERT INTO schema_migrations
-          (version) VALUES ($1)
+          (version, up, down) VALUES ($1, $2, $3)
         SQL
       end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,8 +6,8 @@ require "simplecov-console"
 SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(
   [
     SimpleCov::Formatter::HTMLFormatter,
-    SimpleCov::Formatter::Console
-  ]
+    SimpleCov::Formatter::Console,
+  ],
 )
 SimpleCov.start do
   add_filter "/vendor/"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -15,6 +15,7 @@ SimpleCov.start do
 end
 
 require "minitest/autorun"
+require "minitest/focus"
 require "minitest/reporters"
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 

--- a/test/unit/storage/postgres/schema_migrator_test.rb
+++ b/test/unit/storage/postgres/schema_migrator_test.rb
@@ -21,8 +21,9 @@ describe PGI::SchemaMigrator do
       # Reset to a complety empty database
       subject.migrate!(0)
       pg_conn.exec("DROP TABLE schema_migrations")
+      pg_conn.exec("DROP TABLE schema_lock")
 
-      assert_silent do
+      assert_output(/Attemping to acquire schema lock\nSchema lock acquired/) do
         subject.migrate! # Nil
         _(subject.current_version).must_equal(1)
 

--- a/test/unit/storage/postgres/schema_migrator_test.rb
+++ b/test/unit/storage/postgres/schema_migrator_test.rb
@@ -34,6 +34,24 @@ describe PGI::SchemaMigrator do
         _(subject.current_version).must_equal(0)
       end
     end
+
+    it "automatically rollbacks if there is extra migrations in the db" do
+      subject.migrate!
+      pg_conn.exec(<<~SQL)
+        CREATE TABLE IF NOT EXISTS a(b INT8);
+        DELETE FROM a;
+        INSERT INTO schema_migrations
+        (version, created_at, up, down)
+        VALUES
+        (2, NOW(), '', 'INSERT INTO a (b) VALUES (0)');
+      SQL
+      subject.migrate!
+      result = pg_conn.exec(<<~SQL).to_a.first["b"]
+        SELECT * FROM a;
+      SQL
+      _(result).must_equal 0
+      subject.migrations.delete(2)
+    end
   end
 
   describe "migrate! errors" do
@@ -63,6 +81,40 @@ describe PGI::SchemaMigrator do
         subject.migrate!(99)
       end
       _(e.message).must_equal "FATAL: Migration version does not exist"
+    end
+  end
+
+  describe "schema_lock!" do
+    it "ensures order" do
+      threads = []
+      number = 0
+      5.times do |i|
+        threads.push(Thread.new do
+          subject.schema_lock! do
+            i = number
+            sleep 0.01
+            number = i + 1
+          end
+        end)
+      end
+      threads.each(&:join)
+      _(number).must_equal(5)
+    end
+
+    it "doesnt break if schema_lock table isnt there" do
+      pg_conn.exec("DROP TABLE schema_lock")
+      a = 0
+      subject.schema_lock! do
+        a = 1
+      end
+      _(a).must_equal 1
+      pg_conn.exec(<<~SQL)
+        CREATE TABLE IF NOT EXISTS schema_lock (
+          locked_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NULL,
+          onerow BOOLEAN PRIMARY KEY DEFAULT TRUE CONSTRAINT onerow_uni CHECK (onerow)
+        );
+        INSERT INTO schema_lock DEFAULT VALUES ON CONFLICT DO NOTHING;
+      SQL
     end
   end
 end

--- a/test/unit/storage/postgres/tasks_test.rb
+++ b/test/unit/storage/postgres/tasks_test.rb
@@ -29,7 +29,7 @@ describe "tasks.rb" do
   describe "db:migrate" do
     it "calls migrate! and print out the current verson" do
       execute_rake("db:rollback")
-      assert_output("Schema Version: 1\n") do
+      assert_output("Attemping to acquire schema lock\nSchema lock acquired\nSchema Version: 1\n") do
         execute_rake("db:migrate")
       end
     end
@@ -45,7 +45,9 @@ describe "tasks.rb" do
         "\rI'm giving you 3 seconds to regret and abort.. " \
         "\rI'm giving you 2 seconds to regret and abort.. " \
         "\rI'm giving you 1 seconds to regret and abort.. \n" \
-        "Schema Version: 0\n"
+        "Attemping to acquire schema lock\n" \
+        "Schema lock acquired\n" \
+        "Schema Version: 0\n",
       ) do
         execute_rake("db:rollback")
       end
@@ -65,7 +67,7 @@ describe "tasks.rb" do
     it "destroy all tables in the database" do
       execute_rake("db:migrate") # Make sure there is something to destroy
       assert_output(
-        "Destroying all tables...\n"
+        "Destroying all tables...\n",
       ) do
         execute_rake("db:destroy")
       end


### PR DESCRIPTION
introduce a advisory schema_lock which ensures no 2 instances will ever race condition migrate on top of eachother
also introduce the up and down parts on the schema_migrations table which allows us to automatically run the `down` part if the number migration we're migrating too isnt in the files to read from

to apply this change to existing systems on would need to run this sql first
```sql
alter table schema_migrations add column up text;
alter table schema_migrations add column down text;
          CREATE TABLE IF NOT EXISTS schema_lock (
            locked_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NULL,
            onerow BOOLEAN PRIMARY KEY DEFAULT TRUE CONSTRAINT onerow_uni CHECK (onerow)
          );
          INSERT INTO schema_lock DEFAULT VALUES ON CONFLICT DO NOTHING;
```

these changes are needed for us to be able to nicely do migrations in aws without having to setup a shitton of infra just to perform migrations and rollbacks